### PR TITLE
Installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,13 @@ Propel Admin
 [![Build Status](https://secure.travis-ci.org/sonata-project/SonataPropelAdminBundle.png?branch=master)](http://travis-ci.org/sonata-project/SonataPropelAdminBundle)
 
 This bundle integrates the SonataAdminBundle with the Propel ORM project.
+
+Check out the documentation on [Resources/doc](https://github.com/sonata-project/SonataPropelAdminBundle/tree/master/Resources/doc)
+
+**Warning**: documentation files are not rendering correctly in Github (reStructuredText format)
+and some content might be broken or hidden, make sure to read raw files.
+
+**Google Groups**: For questions and proposals you can post on these google groups
+
+* [Sonata Users](https://groups.google.com/group/sonata-users): For questions on how to use Sonata bundles on your project
+* [Sonata Devs](https://groups.google.com/group/sonata-devs): For questions regarding the development of Sonata bundles

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -1,7 +1,12 @@
 PropelAdmin Bundle
 ==================
 
-This is the ``Propel`` implementation for the ``SonataAdminBundle``.
+This bundle integrates the SonataAdminBundle with the Propel ORM project.
+
+**Google Groups**: For questions and proposals you can post on these google groups
+
+* `Sonata Users <https://groups.google.com/group/sonata-users>`_: For questions on how to use Sonata bundles on your project
+* `Sonata Devs <https://groups.google.com/group/sonata-devs>`_: For questions regarding the development of Sonata bundles
 
 Reference Guide
 ---------------
@@ -10,5 +15,6 @@ Reference Guide
    :maxdepth: 1
    :numbered:
 
+   reference/installation
    reference/admin
    reference/model_filter

--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -1,0 +1,52 @@
+Installation
+============
+
+SonataPropelAdminBundle is part of a set of bundles aimed at abstracting 
+storage connectivity for SonataAdminBundle. As such, SonataPropelAdminBundle
+depends on SonataAdminBundle, and will not work without it. 
+
+.. note::
+    These installation instructions are meant to be used only as part of SonataAdminBundle's
+    installation process, which is documented `here <http://sonata-project.org/bundles/admin/master/doc/reference/installation.html>`_.
+
+Download the bundle
+-------------------
+
+Use composer:
+
+.. code-block:: bash
+
+    php composer.phar require sonata-project/propel-admin-bundle
+
+You'll be asked to type in a version constraint. 'dev-master' will usually get you the latest
+, bleeding edge version. Check `packagist <https://packagist.org/packages/sonata-project/propel-admin-bundle>`_
+for stable and legacy versions:
+
+.. code-block:: bash
+
+    Please provide a version constraint for the sonata-project/propel-admin-bundle requirement: dev-master
+
+
+Enable the bundle
+-----------------
+
+Next, be sure to enable the bundle in your AppKernel.php file:
+
+.. code-block:: php
+
+    <?php
+    // app/AppKernel.php
+    public function registerBundles()
+    {
+        return array(
+            // ...
+            // set up basic sonata requirements
+            // ...
+            new Sonata\PropelAdminBundle\SonataPropelAdminBundle(),
+            // ...
+        );
+    }
+
+.. note::
+    Don't forget that, as part of `SonataAdminBundle's installation instructions <http://sonata-project.org/bundles/admin/master/doc/reference/installation.html>`_,
+    you need to enable additional bundles on AppKernel.php


### PR DESCRIPTION
Install instructions updated, similar to the ones existing on the other 3 sonata admin abstractions bundles.
Made them clearer regarding some details that might be confusing for new users. Also made the google groups description more accurate.

Part of https://github.com/sonata-project/SonataAdminBundle/issues/1520
