### PR TITLE
Fix: version requirement for symfony (allows symfony 2.3)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "propel/propel1": ">=1.6,<2.0",
         "sonata-project/admin-bundle": "2.2.*@dev",
         "sonata-project/block-bundle": "2.2.*@dev",
-        "symfony/symfony": ">=2.2,<2.3",
+        "symfony/symfony": ">=2.2,<2.4-dev",
         "knplabs/knp-menu-bundle": "1.1.x-dev"
     },
     "autoload": {


### PR DESCRIPTION
As pointed out by the issue #8, there is no reason to require a symfony version <2.3
