### PR TITLE
Fix: the ModelManager should retrieve columns by their phpName (and in a...

### DIFF
--- a/Model/ModelManager.php
+++ b/Model/ModelManager.php
@@ -81,7 +81,6 @@ class ModelManager implements ModelManagerInterface
         }
 
         if (!$column = $this->getColumn($class, $name)) {
-        
             return $fieldDescription;
         }
 
@@ -535,6 +534,10 @@ class ModelManager implements ModelManagerInterface
 
         if ($table && $table->hasColumn($property)) {
             return $this->cache[$class.'::'.$property] = $table->getColumn($property);
+        }
+
+        if ($table && $table->hasColumnByInsensitiveCase($property)) {
+            return $this->cache[$class.'::'.$property] = $table->getColumnByInsensitiveCase($property);
         }
     }
 }


### PR DESCRIPTION
...n case-insensitive manner).

Also handles cases where the phpName and the column name are different.
