### PR TITLE
Fixed getNormalizedIdentifier

### DIFF
--- a/Model/ModelManager.php
+++ b/Model/ModelManager.php
@@ -255,18 +255,18 @@ class ModelManager implements ModelManagerInterface
      */
     public function getIdentifierValues($model)
     {
+        $value = null;
+
         if ($model instanceof Persistent) {
             // if an array is returned (composite PK), nothing is done.
             // otherwise we return an array with only one element: the identifier
-            return (array) $model->getPrimaryKey();
+            $value = $model->getPrimaryKey();
+        } elseif ($model instanceof BaseObject && method_exists($model, 'getPrimaryKey')) {
+            // readonly="true" models
+            $value = $model->getPrimaryKey();
         }
 
-        // readonly="true" models
-        if ($model instanceof BaseObject && method_exists($model, 'getPrimaryKey')) {
-            return (array) $model->getPrimaryKey();
-        }
-
-        return null;
+        return empty($value) ? null : (array) $value;
     }
 
     /**
@@ -307,6 +307,10 @@ class ModelManager implements ModelManagerInterface
     {
         if ($model instanceof BaseObject || $model instanceof Persistent) {
             $values = $this->getIdentifierValues($model);
+
+            if (empty($values)) {
+                return null;
+            }
 
             return implode(self::ID_SEPARATOR, $values);
         }

--- a/Tests/Model/ModelManagerTest.php
+++ b/Tests/Model/ModelManagerTest.php
@@ -247,6 +247,10 @@ class ModelManagerTest extends \PHPUnit_Framework_TestCase
 
             array($baseObjectMock,  42,             '42'),
             array($baseObjectMock,  array(24, 42),  '24~42'),
+
+            array($baseObjectMock,  array(),        null),
+            array($baseObjectMock,  '',             null),
+            array($baseObjectMock,  0,              null),
         );
     }
 


### PR DESCRIPTION
in case `$values` is empty we was not returning null and it is a problem in the AdminBundle. The result of this function have to be null in empty case. The regression was caused by https://github.com/sonata-project/SonataPropelAdminBundle/commit/7847ba7c90ac15cbe3b6e03d159e85a9e7315cbc

@K-Phoen Can you review this changeset ? thx
