### PR TITLE
Propel2 Support – WIP

### DIFF
--- a/Datagrid/Pager.php
+++ b/Datagrid/Pager.php
@@ -62,7 +62,7 @@ class Pager extends BasePager
     protected function computeNbResults()
     {
         $nbResultsQuery = clone $this->getQuery();
-        $nbResultsQuery->limit(null)->offset(null);
+        //$nbResultsQuery->limit(null)->offset(null);
 
         return $nbResultsQuery->count();
     }

--- a/Datagrid/ProxyQuery.php
+++ b/Datagrid/ProxyQuery.php
@@ -13,7 +13,8 @@ namespace Sonata\PropelAdminBundle\Datagrid;
 
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 
-use ModelCriteria;
+//use ModelCriteria;
+use Propel\Runtime\ActiveQuery\ModelCriteria;
 use PropelObjectCollection;
 
 /**


### PR DESCRIPTION
Just to reference these changes to other interested developers.

This is my first draft for Propel2 support. There are probably still a lot of cases where this is not enough. Especially the symfony propel1 bridge is still being used. But these changes allowed us to do CRUD operations on Propel2 models.